### PR TITLE
add environment var for seed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbtest"
-version = "0.3.1"
+version = "0.3.2"
 description = "A minimalist property-based testing library based on arbitrary"
 categories = ["development-tools::testing"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This has the advantage that there is no need to recompile the code when changing the seed.
Also it makes it easier to reproduce without changing code.