### PR TITLE
fix: hang on some seeds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,7 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 
     fn try_seed(&mut self, seed: Seed) -> arbitrary::Result<()> {
-        seed.fill(&mut self.buffer);
+        seed.fill(&mut self.buffer, self.options.size_max);
         let mut u = arbitrary::Unstructured::new(&self.buffer);
         (self.property)(&mut u)
     }
@@ -542,7 +542,7 @@ impl Seed {
     fn rand(self) -> u32 {
         (self.repr >> u32::BITS) as u32
     }
-    fn fill(self, buf: &mut Vec<u8>) {
+    fn fill(self, buf: &mut Vec<u8>, size_max: u32) {
         buf.clear();
         buf.reserve(self.size() as usize);
         let mut random = self.rand();
@@ -552,7 +552,7 @@ impl Seed {
             random ^= random << 5;
             random
         });
-        while buf.len() < self.size() as usize {
+        while buf.len() < self.size().min(size_max) as usize {
             buf.extend(rng.next().unwrap().to_le_bytes());
         }
     }


### PR DESCRIPTION
If the seed happens to make the lower 32 bits a large number then `Seed::fill` previously would take a long time to generate entropy that won't be used.