### PR TITLE
Make the crate compatible with `wasm32` architecture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ members = ["xtask"]
 [dependencies]
 arbitrary = "1.3.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "1.1.0"
+
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive" ] }
 regex = { version = "0.1.5", package = "regex-lite" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,8 +248,15 @@ use std::{
     fmt,
     hash::{BuildHasher, Hasher},
     panic::AssertUnwindSafe,
-    time::{Duration, Instant},
+    time::Duration,
 };
+
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+
 
 #[doc(no_inline)]
 pub use arbitrary;
@@ -456,7 +463,7 @@ impl<'a, 'b> Context<'a, 'b> {
         }
 
         let mut seed = seed;
-        let t = std::time::Instant::now();
+        let t = Instant::now();
 
         let minimizers = [|s| s / 2, |s| s * 9 / 10, |s| s - 1];
         let mut minimizer = 0;


### PR DESCRIPTION
With some rudimentary changes to timing utilities this simple crate is able to work on `wasm32` architecture. This PR introduces those changes.